### PR TITLE
feat: Add --exclude option to --automatic mode

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -137,6 +137,7 @@ async function main(): Promise<void> {
 
             } else {
                 printUsageAndExit("CRITICAL ERROR: --automatic option requires either 2 arguments (<EXTENSIONS> <branch_name>) or 4 arguments (<EXTENSIONS> <branch_name> --exclude <DIR_LIST>).");
+                return; // Explicitly exit path for TSC
             }
 
             if (extensionsInput.startsWith('--')) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -25,7 +25,7 @@ export function printUsageAndExit(errorMessage?: string, detailed: boolean = fal
     console.error(`  taylored --verify-remove <taylored_file_name>`);
     console.error(`  taylored --save <branch_name>`);
     console.error(`  taylored --list`);
-    console.error(`  taylored --automatic <EXTENSIONS> <branch_name>`);
+    console.error(`  taylored --automatic <EXTENSIONS> <branch_name> [--exclude <DIR_LIST>]`);
     console.error(`  taylored --offset <taylored_file_name> [--message "Custom commit message"]`);
     console.error(`  taylored --data <taylored_file_name>`);
 
@@ -37,6 +37,7 @@ export function printUsageAndExit(errorMessage?: string, detailed: boolean = fal
         console.error(`  <branch_name>             : Branch name. Used by --save (target for diff) and --automatic (target for comparison).`);
         console.error(`                            Output for --save: ${TAYLORED_DIR_NAME}/<branch_name_sanitized>${TAYLORED_FILE_EXTENSION}`);
         console.error(`  <EXTENSIONS>              : File extension(s) to scan (e.g., 'ts' or 'ts,js,py'). Used by --automatic.`);
+        console.error(`  <DIR_LIST>                : Optional. Comma-separated list of directory names to exclude (e.g., 'dist,build,test'). Used by --automatic with --exclude.`);
         console.error("\nOptions:");
         console.error(`  --add                     : Apply changes from '${TAYLORED_DIR_NAME}/<file_name>' to current directory.`);
         console.error(`  --remove                  : Revert changes from '${TAYLORED_DIR_NAME}/<file_name>' in current directory.`);
@@ -45,7 +46,12 @@ export function printUsageAndExit(errorMessage?: string, detailed: boolean = fal
         console.error(`  --save                    : Generate diff file into '${TAYLORED_DIR_NAME}/<branch_name_sanitized>${TAYLORED_FILE_EXTENSION}'.`);
         console.error(`                            (File saved only if diff is all additions or all deletions of lines).`);
         console.error(`  --list                    : List all ${TAYLORED_FILE_EXTENSION} files in the '${TAYLORED_DIR_NAME}/' directory.`);
-        console.error(`  --automatic <EXTENSIONS> <branch_name> : Automatically search for taylored blocks in files with specified <EXTENSIONS> (e.g., .js, .ts, .py) using <branch_name> as the target for comparison, and create taylored files from them. Markers: <taylored NUMERO> and </taylored> (where NUMERO is an integer).`);
+        console.error(`  --automatic <EXTENSIONS> <branch_name> [--exclude <DIR_LIST>] :`);
+        console.error(`                            Automatically search for taylored blocks in files with specified <EXTENSIONS>`);
+        console.error(`                            (e.g., .js, .ts, .py) using <branch_name> as the target for comparison,`);
+        console.error(`                            and create taylored files from them. Markers: <taylored NUMERO> and </taylored>`);
+        console.error(`                            (where NUMERO is an integer).`);
+        console.error(`                            If --exclude is provided, specified directories (and their subdirectories) will be ignored.`);
         console.error(`  --offset                  : Update offsets for a given patch file in '${TAYLORED_DIR_NAME}/'.`);
         console.error(`  --message "Custom Text"   : Optional. Used with --offset. A warning is shown as this is not used by the new offset logic.`);
         console.error(`  --data                    : Extract and print message from a taylored file. Prints empty string if not found.`);

--- a/tests/e2e/automatic-git.test.ts
+++ b/tests/e2e/automatic-git.test.ts
@@ -336,15 +336,15 @@ console.log(jsVar);`;
     test('Correctly excludes specified directories and their subdirectories', () => {
       testRepoPath = setupTestRepo('automatic_exclude_dirs');
 
-      // Create files with taylored blocks
-      createFileAndCommit(testRepoPath, 'file1.js', '// Root file\n// <taylored 1>\n// Block 1 content\n// </taylored>', 'Add file1.js');
+      // Create files with taylored blocks, ensuring all end with a newline
+      createFileAndCommit(testRepoPath, 'file1.js', '// Root file\n// <taylored 1>\n// Block 1 content\n// </taylored>\n', 'Add file1.js');
 
-      createFileAndCommit(testRepoPath, path.join('excluded_dir1', 'file2.js'), '// Excluded dir1 file\n// <taylored 2>\n// Block 2 content\n// </taylored>', 'Add file2.js in excluded_dir1');
-      createFileAndCommit(testRepoPath, path.join('excluded_dir1', 'sub_excluded_dir', 'file_in_sub.js'), '// Sub Excluded dir1 file\n// <taylored 5>\n// Block 5 content\n// </taylored>', 'Add file_in_sub.js in excluded_dir1/sub_excluded_dir');
+      createFileAndCommit(testRepoPath, path.join('excluded_dir1', 'file2.js'), '// Excluded dir1 file\n// <taylored 2>\n// Block 2 content\n// </taylored>\n', 'Add file2.js in excluded_dir1');
+      createFileAndCommit(testRepoPath, path.join('excluded_dir1', 'sub_excluded_dir', 'file_in_sub.js'), '// Sub Excluded dir1 file\n// <taylored 5>\n// Block 5 content\n// </taylored>\n', 'Add file_in_sub.js in excluded_dir1/sub_excluded_dir');
 
-      createFileAndCommit(testRepoPath, path.join('not_excluded_dir', 'file3.js'), '// Not excluded dir file\n// <taylored 3>\n// Block 3 content\n// </taylored>', 'Add file3.js in not_excluded_dir');
+      createFileAndCommit(testRepoPath, path.join('not_excluded_dir', 'file3.js'), '// Not excluded dir file\n// <taylored 3>\n// Block 3 content\n// </taylored>\n', 'Add file3.js in not_excluded_dir');
 
-      createFileAndCommit(testRepoPath, path.join('excluded_dir2', 'file4.js'), '// Excluded dir2 file\n// <taylored 4>\n// Block 4 content\n// </taylored>', 'Add file4.js in excluded_dir2');
+      createFileAndCommit(testRepoPath, path.join('excluded_dir2', 'file4.js'), '// Excluded dir2 file\n// <taylored 4>\n// Block 4 content\n// </taylored>\n', 'Add file4.js in excluded_dir2');
 
       // Run the taylored command with --exclude
       // Assuming 'main' is the default branch after setupTestRepo


### PR DESCRIPTION
This commit introduces a new optional `--exclude` parameter for the `--automatic` mode in Taylored.

When using `taylored --automatic <EXTENSIONS> <branch_name>`, you can now also provide `--exclude <DIR_LIST>`, where `<DIR_LIST>` is a comma-separated list of directory names that should be excluded from the file scan.

Key changes:
- Modified `index.ts` to parse the new `--exclude` argument.
- Updated `lib/handlers/automatic-handler.ts`:
    - `handleAutomaticOperation` now accepts and processes the list of excluded directories.
    - `findFilesRecursive` now takes the exclusion list into account and skips specified directories and their subdirectories.
    - The hardcoded exclusion of `node_modules` has been removed from `findFilesRecursive`. If you wish to exclude `node_modules`, you must now explicitly add it to the `--exclude` parameter (e.g., `--exclude node_modules`). The directories `.git` and `.taylored` remain hardcoded exclusions.
- Added a new test suite in `tests/e2e/automatic-git.test.ts` with multiple test cases to verify the `--exclude` functionality, including:
    - Exclusion of single and multiple directories.
    - Exclusion of nested directories.
    - Behavior with non-existent directories in the exclude list.
    - Behavior with an empty exclude list.
- Updated `lib/utils.ts` to include the `--exclude` parameter in the `printUsageAndExit` message.
- Updated `README.md` to document the new `--exclude` parameter, its usage, and examples.

This enhancement provides you with more granular control over the directories scanned during the automatic taylored block extraction process.