### PR TITLE
Fix: Ensure compute scripts execute reliably on Windows

### DIFF
--- a/lib/handlers/automatic-handler.ts
+++ b/lib/handlers/automatic-handler.ts
@@ -190,11 +190,8 @@ export async function handleAutomaticOperation(
 
                 let scriptResult = '';
                 try {
-                    // Add execute permission to the temporary script file before execution
-                    await fs.chmod(tempScriptPath, 0o755); // rwxr-xr-x
-
                     // Execute the temporary script directly, relying on its shebang
-                    scriptResult = execSync(`"${tempScriptPath}"`, { cwd: CWD, encoding: 'utf8', stdio: 'pipe' });
+                    scriptResult = execSync(`node "${tempScriptPath}"`, { cwd: CWD, encoding: 'utf8', stdio: 'pipe' });
 
                 } catch (error: any) {
                     // Differentiate error source for better logging


### PR DESCRIPTION
The automatic command's `compute` functionality was failing in tests on Windows. This was due to relying on direct script execution (`"${tempScriptPath}"`) and `fs.chmod`, which does not reliably make arbitrary files executable as Node.js scripts on Windows in the same way it does on Unix-like systems.

This commit modifies `automatic-handler.ts` to explicitly invoke `node` when executing the temporary compute script (e.g., `node "${tempScriptPath}"`). The unnecessary `fs.chmod` call for the temporary script has also been removed.

This change ensures that compute scripts are executed in a cross-platform compatible manner, resolving the test failures observed on Windows.