### PR TITLE
Fix: Ensure --automatic non-compute saves directly to NUMERO.taylored

### DIFF
--- a/lib/handlers/automatic-handler.ts
+++ b/lib/handlers/automatic-handler.ts
@@ -329,17 +329,6 @@ export async function handleAutomaticOperation(
             } else {
                 // Existing non-compute logic - wrapped correctly now
                 try {
-                    await fs.access(intermediateMainTayloredPath);
-                    const message = `CRITICAL ERROR: Intermediate file ${intermediateMainTayloredPath} already exists. Please remove or rename it.`;
-                    console.error(message);
-                    throw new Error(message);
-                } catch (error: any) {
-                    if (error.code !== 'ENOENT') {
-                        throw error;
-                    }
-                }
-
-                try {
                     await fs.access(targetTayloredFilePath);
                     const message = `CRITICAL ERROR: Target file ${targetTayloredFilePath} already exists. Please remove or rename it.`;
                     console.error(message);
@@ -363,8 +352,7 @@ export async function handleAutomaticOperation(
                     await fs.writeFile(originalFilePath, currentFileLines.join('\n'));
                     execSync(`git add "${originalFilePath}"`, { cwd: CWD, ...execOpts });
                     execSync(`git commit -m "Temporary: Remove block ${numero} from ${path.basename(originalFilePath)}"`, { cwd: CWD, ...execOpts });
-                    await handleSaveOperation(branchName, CWD);
-                    await fs.rename(intermediateMainTayloredPath, targetTayloredFilePath);
+                    await handleSaveOperation(branchName, CWD, numero);
                     console.log(`Successfully created ${targetTayloredFilePath} for block ${numero} from ${originalFilePath}`);
                     totalBlocksProcessed++;
                 } catch (error: any) {
@@ -384,10 +372,6 @@ export async function handleAutomaticOperation(
                     } catch (deleteBranchError: any) {
                         console.warn(`Warning: Failed to delete temporary branch '${tempBranchName}' during cleanup. May require manual cleanup. ${deleteBranchError.message}`);
                     }
-                    try {
-                        await fs.access(intermediateMainTayloredPath);
-                        await fs.unlink(intermediateMainTayloredPath);
-                    } catch (e) { /* File doesn't exist or can't be accessed, ignore */ }
                 }
             } // This closes the `if (computeCharsToStrip !== undefined)` block, NOT the `else` for non-compute
         }

--- a/lib/handlers/save-handler.ts
+++ b/lib/handlers/save-handler.ts
@@ -8,9 +8,12 @@ import { getAndAnalyzeDiff } from '../utils';
  * Handles the --save operation: generates a .taylored file from a branch diff.
  * @param branchName The name of the branch to diff against HEAD.
  * @param CWD The current working directory (Git repository root).
+ * @param outputFileNameOverride Optional override for the output file name.
  */
-export async function handleSaveOperation(branchName: string, CWD: string): Promise<void> {
-    const outputFileName = `${branchName.replace(/[/\\]/g, '-')}${TAYLORED_FILE_EXTENSION}`;
+export async function handleSaveOperation(branchName: string, CWD: string, outputFileNameOverride?: string): Promise<void> {
+    const outputFileName = outputFileNameOverride
+        ? `${outputFileNameOverride}${TAYLORED_FILE_EXTENSION}`
+        : `${branchName.replace(/[/\\]/g, '-')}${TAYLORED_FILE_EXTENSION}`;
     const targetDirectoryPath = path.join(CWD, TAYLORED_DIR_NAME);
     const resolvedOutputFileName = path.join(targetDirectoryPath, outputFileName);
 

--- a/tests/e2e/automatic-git.test.ts
+++ b/tests/e2e/automatic-git.test.ts
@@ -97,26 +97,6 @@ describe('Automatic Command (Git Workflow)', () => {
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("CRITICAL ERROR: Uncommitted changes or untracked files in the repository.");
     });
-    
-    test('Intermediate .taylored/main.taylored Must Not Exist: Fails if it exists', () => {
-      testRepoPath = setupTestRepo('main_taylored_exists');
-      createFileAndCommit(testRepoPath, 'src/app.ts', '// File content\n// <taylored number="1">\n// block\n// </taylored>', 'Add app.ts');
-      
-      const tayloredDirPath = path.join(testRepoPath, TAYLORED_DIR_NAME);
-      fs.mkdirSync(tayloredDirPath, { recursive: true });
-      // Create AND commit the conflicting file to pass the "dirty repo" check
-      createFileAndCommit(testRepoPath, path.join(TAYLORED_DIR_NAME, `main${TAYLORED_FILE_EXTENSION}`), 'dummy content', 'add main.taylored');
-            
-      const result = runTayloredCommand(testRepoPath, '--automatic ts main');
-      if (result.status === 0) {
-        console.log("Test 'Intermediate .taylored/main.taylored Must Not Exist' unexpectedly got status 0.");
-        console.log("STDOUT:", result.stdout);
-        console.log("STDERR:", result.stderr);
-      }
-      // Application should exit with non-zero status on this critical error.
-      expect(result.status).not.toBe(0); 
-      expect(result.stderr).toMatch(/CRITICAL ERROR: Intermediate file .*main\.taylored already exists/);
-    });
 
     test('Target .taylored/NUMERO.taylored Must Not Exist: Fails if it exists', () => {
       testRepoPath = setupTestRepo('numero_taylored_exists');


### PR DESCRIPTION
The 'taylored --automatic' command, for non-compute blocks, was internally using 'handleSaveOperation' which would first save a patch based on the target branch name (e.g., 'main.taylored'). This intermediate file was then renamed to 'NUMERO.taylored'. This was inconsistent with the expectation that the operation should more directly result in 'NUMERO.taylored' as per the README's description of the --automatic command's output.

This commit addresses the issue by:
1. Modifying `handleSaveOperation` to accept an optional `outputFileNameOverride` parameter. If provided, this override (e.g., the 'numero' from the taylored block) is used directly for the output filename. If not provided (as in the case of `taylored --save <branch_name>`), it defaults to the previous behavior of using the sanitized branch name.
2. Updating `handleAutomaticOperation` for its non-compute path to call `handleSaveOperation` with the block's 'numero' as the `outputFileNameOverride`.
3. Removing the subsequent file renaming operation and the logic handling the intermediate file (e.g., `main.taylored`) in the non-compute path of `handleAutomaticOperation`, as it's no longer needed.
4. Adjusting E2E tests by removing an obsolete test case in `automatic-git.test.ts` that specifically checked for the existence of the now-removed intermediate file. All E2E tests pass with these changes, confirming that both `--automatic` and `--save` commands function correctly.

This change streamlines the file-saving process for non-compute blocks in the --automatic mode and aligns the behavior more closely with the documented output naming convention.