### PR TITLE
Refactor: Replace uuid dependency with crypto.randomUUID

### DIFF
--- a/lib/handlers/buy-handler.ts
+++ b/lib/handlers/buy-handler.ts
@@ -5,7 +5,7 @@ import { validateTaysellFileContent, TaysellFile } from '../taysell-utils';
 import { TAYLORED_DIR_NAME, TAYLORED_FILE_EXTENSION } from '../constants';
 //import { handleApplyOperation } from '../apply-logic';
 import { printUsageAndExit } from '../utils';
-import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto';
 import inquirer from 'inquirer';
 
 /**
@@ -262,7 +262,7 @@ export async function handleBuyCommand(
     }
 
 
-    const cliSessionId = uuidv4();
+    const cliSessionId = crypto.randomUUID();
     const initiatePaymentUrlWithParams = `${endpoints.initiatePaymentUrl}?cliSessionId=${cliSessionId}`;
 
     console.log('CLI: Opening browser for payment approval...');

--- a/lib/handlers/create-taysell-handler.ts
+++ b/lib/handlers/create-taysell-handler.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import inquirer from 'inquirer';
-import { v4 as uuidv4 } from 'uuid'; // For generating patchId
+import * as crypto from 'crypto'; // For generating patchId
 import { encryptAES256GCM } from '../taysell-utils'; // Corrected path
 import { TAYLORED_FILE_EXTENSION } from '../constants'; // Assuming this exists for .taylored extension
 
@@ -131,7 +131,7 @@ export async function handleCreateTaysell(
     questions.push(
         { type: 'input', name: 'patchName', message: 'Enter the commercial name for this patch:', default: patchFileNameBase.replace(TAYLORED_FILE_EXTENSION, '') },
         { type: 'input', name: 'patchDescription', message: 'Enter a description for this patch:', default: descriptionInput || 'No description provided.'},
-        { type: 'input', name: 'patchId', message: 'Enter a unique ID for this patch (or press Enter to generate one):', default: patchIdFromEnv || uuidv4() },
+            { type: 'input', name: 'patchId', message: 'Enter a unique ID for this patch (or press Enter to generate one):', default: patchIdFromEnv || crypto.randomUUID() },
         { type: 'input', name: 'tayloredVersion', message: 'Enter the required taylored CLI version (e.g., >=6.8.21):', default: '>=6.8.21'}, // TODO: Read from current CLI version?
         { type: 'input', name: 'price', message: 'Enter the price (e.g., 9.99):', default: priceInput, validate: (input: string) => !isNaN(parseFloat(input)) || 'Invalid price.' },
         { type: 'input', name: 'currency', message: 'Enter the currency code (e.g., USD, EUR):', default: 'USD', validate: (input: string) => input.trim().length === 3 || 'Currency code must be 3 letters.'}
@@ -152,7 +152,7 @@ export async function handleCreateTaysell(
         answers = {
             patchName: patchFileNameBase.replace(TAYLORED_FILE_EXTENSION, ''),
             patchDescription: descriptionInput || 'Default test description',
-            patchId: patchIdFromEnv || uuidv4(),
+            patchId: patchIdFromEnv || crypto.randomUUID(),
             tayloredVersion: '>=6.8.21',
             price: priceInput || '0.00',
             currency: 'USD',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "taylored",
-  "version": "7.0.14",
+  "version": "7.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taylored",
-      "version": "7.0.14",
+      "version": "7.0.16",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.3.0",
         "inquirer": "^12.6.3",
         "open": "^10.1.2",
-        "parse-diff": "^0.11.1",
-        "uuid": "^11.1.0"
+        "parse-diff": "^0.11.1"
       },
       "bin": {
         "taylored": "dist/index.js"
@@ -25,7 +24,6 @@
         "@types/inquirer": "^9.0.8",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.29",
-        "@types/uuid": "^10.0.0",
         "babel-jest": "^29.7.0",
         "babel-plugin-transform-import-meta": "^2.3.3",
         "jest": "^29.7.0",
@@ -2586,12 +2584,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5640,18 +5632,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taylored",
-  "version": "7.0.14",
+  "version": "7.0.16",
   "description": "Make changes to a branch a plugin. A command-line tool to manage and apply plugins '.taylored'. Supports applying, removing, verifying plugins, and generating them from branch (GIT).",
   "keywords": [
     "plugins",
@@ -54,8 +54,7 @@
     "fs-extra": "^11.3.0",
     "inquirer": "^12.6.3",
     "open": "^10.1.2",
-    "parse-diff": "^0.11.1",
-    "uuid": "^11.1.0"
+    "parse-diff": "^0.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",
@@ -64,7 +63,6 @@
     "@types/inquirer": "^9.0.8",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.29",
-    "@types/uuid": "^10.0.0",
     "babel-jest": "^29.7.0",
     "babel-plugin-transform-import-meta": "^2.3.3",
     "jest": "^29.7.0",

--- a/tests/unit/buy-handler.test.ts
+++ b/tests/unit/buy-handler.test.ts
@@ -21,8 +21,9 @@ jest.mock('open');
 jest.mock('https');
 jest.mock('../../lib/apply-logic');
 jest.mock('../../lib/utils');
-jest.mock('uuid', () => ({
-    v4: jest.fn(() => 'mock-cli-session-id'), // Consistent mock UUID
+jest.mock('crypto', () => ({
+    ...jest.requireActual('crypto'), // Import and retain default behavior
+    randomUUID: jest.fn(() => 'mock-cli-session-id'), // Consistent mock UUID
 }));
 
 // Simulate polling logic for tests

--- a/tests/unit/create-taysell-handler.test.ts
+++ b/tests/unit/create-taysell-handler.test.ts
@@ -5,15 +5,21 @@ import { handleCreateTaysell } from '../../lib/handlers/create-taysell-handler';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import inquirer from 'inquirer';
-import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto'; // Import crypto
 import * as taysellUtils from '../../lib/taysell-utils';
 import { TAYLORED_FILE_EXTENSION } from '../../lib/constants';
 
 jest.mock('fs-extra');
 jest.mock('inquirer');
-jest.mock('uuid', () => ({
-    v4: jest.fn(() => 'mock-uuid-v4'),
-}));
+// Mock crypto's randomUUID with a correctly formatted UUID string
+jest.mock('crypto', () => {
+  const originalCrypto = jest.requireActual('crypto');
+  return {
+    __esModule: true, // Try indicating it's an ES module
+    ...originalCrypto,
+    randomUUID: () => '123e4567-e89b-12d3-a456-426614174000', // Direct function
+  };
+});
 jest.mock('../../lib/taysell-utils', () => ({
     ...jest.requireActual('../../lib/taysell-utils'),
     encryptAES256GCM: jest.fn(),
@@ -33,9 +39,27 @@ describe('handleCreateTaysell', () => {
         SELLER_CONTACT: 'e2e@example.com',
     };
 
+    // No direct manipulation of crypto here
+
     beforeEach(() => {
         jest.resetAllMocks();
         process.env.JEST_WORKER_ID = '1';
+
+        // crypto.randomUUID is mocked via jest.mock at the top of the file
+        // Add explicit mock for inquirer.prompt
+        jest.mocked(inquirer.prompt).mockResolvedValue({
+            serverBaseUrl: defaultEnvConfig.SERVER_BASE_URL, // Assuming this is read from env or default
+            patchEncryptionKey: defaultEnvConfig.PATCH_ENCRYPTION_KEY, // Assuming this is read from env or default
+            patchName: mockTayloredFileName.replace(TAYLORED_FILE_EXTENSION, ''),
+            patchDescription: 'Default test description', // Default or passed in
+            patchId: '123e4567-e89b-12d3-a456-426614174000', // Ensure this is the mocked UUID
+            tayloredVersion: '>=6.8.21',
+            price: '0.00', // Default or passed in
+            currency: 'USD',
+            sellerName: defaultEnvConfig.SELLER_NAME,
+            sellerWebsite: defaultEnvConfig.SELLER_WEBSITE,
+            sellerContact: defaultEnvConfig.SELLER_CONTACT,
+        });
 
         jest.spyOn(console, 'log').mockImplementation();
         jest.spyOn(console, 'error').mockImplementation();
@@ -51,12 +75,13 @@ describe('handleCreateTaysell', () => {
         jest.mocked(fs.writeFile).mockImplementation(async () => {});
         jest.mocked(fs.writeJson).mockResolvedValue(undefined);
         jest.mocked(taysellUtils.encryptAES256GCM).mockReturnValue('encrypted-patch-content');
-        (uuidv4 as jest.Mock).mockReturnValue('mock-uuid-v4');
+        // No longer need to mock uuidv4 directly as jest.mock('crypto') handles it.
     });
 
     afterEach(() => {
         delete process.env.JEST_WORKER_ID;
         jest.restoreAllMocks();
+        // No need to restore crypto.randomUUID as it's handled by jest.mock
     });
 
     it('should create .taysell package using non-interactive test defaults', async () => {
@@ -70,7 +95,7 @@ describe('handleCreateTaysell', () => {
         expect(fs.writeJson).toHaveBeenCalledWith(
             path.join(mockCwd, 'my_patch.taysell'),
             expect.objectContaining({
-                patchId: 'mock-uuid-v4',
+                patchId: '123e4567-e89b-12d3-a456-426614174000',
                 metadata: expect.objectContaining({
                     name: 'my_patch',
                     description: cliDesc,
@@ -102,9 +127,9 @@ describe('handleCreateTaysell', () => {
         expect(fs.writeJson).toHaveBeenCalledWith(
             path.join(mockCwd, 'my_patch.taysell'),
             expect.objectContaining({
-                patchId: 'mock-uuid-v4', // Should also check this as it's part of the output
+                patchId: '123e4567-e89b-12d3-a456-426614174000', // Should also check this as it's part of the output
                 endpoints: expect.objectContaining({
-                    initiatePaymentUrl: 'http://test.com/pay/mock-uuid-v4' // Corrected fallback
+                    initiatePaymentUrl: 'http://test.com/pay/123e4567-e89b-12d3-a456-426614174000' // Corrected fallback
                 }),
                 sellerInfo: expect.objectContaining({
                     name: 'E2E Test Seller' // Corrected fallback


### PR DESCRIPTION
I've removed the 'uuid' package and its corresponding '@types/uuid' devDependency. Then, I updated the code in `lib/handlers/buy-handler.ts` and `lib/handlers/create-taysell-handler.ts` to use the built-in `crypto.randomUUID()` method for generating UUIDs.

I also adjusted the unit tests in `tests/unit/buy-handler.test.ts` and `tests/unit/create-taysell-handler.test.ts` to correctly mock `crypto.randomUUID()` instead of the removed `uuid.v4`. All tests pass after these changes.